### PR TITLE
Update example configurationValues to work out-of-the-box.

### DIFF
--- a/example/changelogs/configurationValues.txt
+++ b/example/changelogs/configurationValues.txt
@@ -1,6 +1,9 @@
 # Set these values in CI/CD configuration to connect to an embedded H2 database and run example
+# NOTE: The username is missing the second "i" in Liquibase. liqubase is the correct spelling.
 
-changeLogFile: samplechangelog.h2.sql
+operation: 'update'
+classpath: /liquibase/changelog:/liquibase/classpath:/
+changeLogFile: /example/changelogs/samplechangelog.h2.sql
 url: jdbc:h2:file:./H2_project/h2tutorial
 username: liqubase
 password: password


### PR DESCRIPTION
The configurationValues.txt did not allow me to run the liquibase-github-action-example without modification. I also noticed the username for the database is 'liqubase' and not 'liquibase.' I added a note so people don't get tripped up if they type the information rather than do a direct copy'n'paste.